### PR TITLE
Create  Remove Consecutive K element records

### DIFF
--- a/R/Remove Consecutive K element records
+++ b/R/Remove Consecutive K element records
@@ -1,0 +1,19 @@
+# Python3 code to demonstrate working of 
+# Remove Consecutive K element records
+# Using zip() + list comprehension
+
+# initializing list
+test_list = [(4, 5, 6, 3), (5, 6, 6, 9), (1, 3, 5, 6), (6, 6, 7, 8)]
+
+# printing original list
+print("The original list is : " + str(test_list))
+
+# initializing K 
+K = 6
+
+# Remove Consecutive K element records
+# Using zip() + list comprehension
+res = [idx for idx in test_list if (K, K) not in zip(idx, idx[1:])]
+
+# printing result 
+print("The records after removal : " + str(res)) 


### PR DESCRIPTION
Sometimes, while working with Python records, we can have a problem in which we need to remove records on the basis of presence of consecutive K elements in tuple. This kind of problem is peculiar but can have applications in data domains. Let’s discuss certain ways in which this task can be performed.